### PR TITLE
Reimplement firewall policy caching for different WAFs

### DIFF
--- a/bindings/akamai/src/index.ts
+++ b/bindings/akamai/src/index.ts
@@ -293,7 +293,6 @@ export class AkamaiContext extends RecaptchaContext {
   readonly sessionPageCookie = "recaptcha-akam-t";
   readonly challengePageCookie = "recaptcha-akam-e";
   readonly environment: [string, string] = [pkg.name, pkg.version];
-  readonly httpGetCachingEnabled = true;
   start_time: number;
   performance_counters: Array<[string, number]> = [];
 

--- a/bindings/cloudflare/src/index.ts
+++ b/bindings/cloudflare/src/index.ts
@@ -53,7 +53,6 @@ export class CloudflareContext extends RecaptchaContext {
   readonly sessionPageCookie = "recaptcha-cf-t";
   readonly challengePageCookie = "recaptcha-cf-e";
   readonly environment: [string, string] = [pkg.name, pkg.version];
-  readonly httpGetCachingEnabled = true;
   start_time: number;
   performance_counters: Array<[string, number]> = [];
 

--- a/bindings/fastly/src/index.ts
+++ b/bindings/fastly/src/index.ts
@@ -104,7 +104,6 @@ export class FastlyContext extends RecaptchaContext {
   readonly sessionPageCookie = "recaptcha-fastly-t";
   readonly challengePageCookie = "recaptcha-fastly-e";
   readonly environment: [string, string] = [pkg.name, pkg.version];
-  readonly httpGetCachingEnabled = true;
   start_time: number;
   performance_counters: Array<[string, number]> = [];
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,7 +71,6 @@ const testConfig: RecaptchaConfig = {
 class TestContext extends RecaptchaContext {
   sessionPageCookie = "recaptcha-test-t";
   challengePageCookie = "recaptcha-test-e";
-  httpGetCachingEnabled = false;
   exceptions: any[] = [];
   log_messages: Array<[LogLevel, string[]]> = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,6 @@ export abstract class RecaptchaContext {
   log_messages: Array<[LogLevel, string[]]> = [];
   debug_trace: DebugTrace;
   readonly environment: [string, string] = ["[npm] @google-cloud/recaptcha", ""];
-  abstract readonly httpGetCachingEnabled: boolean;
   abstract readonly sessionPageCookie: string;
   abstract readonly challengePageCookie: string;
 

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -82,9 +82,6 @@ export function policyConditionMatch(policy: FirewallPolicy, req: EdgeRequest): 
  */
 export async function localPolicyAssessment(context: RecaptchaContext, req: EdgeRequest): Promise<LocalAssessment> {
   // Optimization to inspect a cached copy of the firewall policies if HTTP caching is enabled.
-  if (context.httpGetCachingEnabled) {
-    // TODO: platforms-explicit caching
-  }
   let resp;
   try {
     context.log_performance_debug("[rpc] callListFirewallPolicies - start");


### PR DESCRIPTION
We don't need an extra boolean httpGetCachingEnabled to check if there's WAF-specific caching mechanism. The function context.fetch_list_firewall_policies() should do the work when it's called here: https://github.com/GoogleCloudPlatform/recaptcha-waf/blob/main/src/listFirewallPolicies.ts#L50