### PR TITLE
remove 'concurrency' group from build-core

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-core
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
concurrency groups only allow 1 waiting task at a time. With 3 platforms, it cancels a task and breaks our artifact creation workflow.

see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#using-concurrency-in-different-scenarios