### PR TITLE
Gitignore

### DIFF
--- a/bindings/akamai/.gitignore
+++ b/bindings/akamai/.gitignore
@@ -1,0 +1,7 @@
+dist
+pkg
+bin
+node_modules
+examples/**/node_modules
+examples/**/.wrangler
+examples/**/dist

--- a/bindings/akamai/.gitignore
+++ b/bindings/akamai/.gitignore
@@ -1,7 +1,5 @@
 dist
 pkg
-bin
 node_modules
 examples/**/node_modules
-examples/**/.wrangler
 examples/**/dist

--- a/bindings/cloudflare/.gitignore
+++ b/bindings/cloudflare/.gitignore
@@ -1,0 +1,7 @@
+dist
+pkg
+bin
+node_modules
+examples/**/node_modules
+examples/**/.wrangler
+examples/**/dist

--- a/bindings/cloudflare/.gitignore
+++ b/bindings/cloudflare/.gitignore
@@ -1,6 +1,5 @@
 dist
 pkg
-bin
 node_modules
 examples/**/node_modules
 examples/**/.wrangler

--- a/bindings/fastly/.gitignore
+++ b/bindings/fastly/.gitignore
@@ -1,0 +1,7 @@
+dist
+pkg
+bin
+node_modules
+examples/**/node_modules
+examples/**/.wrangler
+examples/**/dist

--- a/bindings/fastly/.gitignore
+++ b/bindings/fastly/.gitignore
@@ -3,5 +3,4 @@ pkg
 bin
 node_modules
 examples/**/node_modules
-examples/**/.wrangler
 examples/**/dist

--- a/bindings/xlb/.gitignore
+++ b/bindings/xlb/.gitignore
@@ -1,0 +1,8 @@
+dist
+pkg
+bin
+node_modules
+gen
+examples/**/node_modules
+examples/**/.wrangler
+examples/**/dist

--- a/bindings/xlb/.gitignore
+++ b/bindings/xlb/.gitignore
@@ -1,8 +1,6 @@
 dist
 pkg
-bin
 node_modules
 gen
 examples/**/node_modules
-examples/**/.wrangler
 examples/**/dist


### PR DESCRIPTION
the motivation is to prevent these files from showing up in binding specific npm packages.

This can be done with a .npmignore, but the npm pack command checks .gitignore too, and we don't want any of this in git either.

see: https://docs.npmjs.com/cli/v9/using-npm/developers#keeping-files-out-of-your-package