### PR TITLE
Parsing client IP from XFF header correctly

### DIFF
--- a/bindings/xlb/src/edge_binding.ts
+++ b/bindings/xlb/src/edge_binding.ts
@@ -336,7 +336,7 @@ export class XlbContext extends RecaptchaContext {
       return undefined;
     }
     const clientIpIdx = Math.max(forwardedArr.length - 2, 0);
-    return forwardedArr[clientIpIdx];
+    return forwardedArr[clientIpIdx].trim();
   }
 
   logException(e: any) {

--- a/bindings/xlb/src/index.test.ts
+++ b/bindings/xlb/src/index.test.ts
@@ -190,7 +190,7 @@ describe("WAF Callouts Suite", async function () {
               },
               {
                 key: "X-Forwarded-For",
-                rawValue: new TextEncoder().encode("127.0.0.1,34.45.56.666"),
+                rawValue: new TextEncoder().encode("garbage,127.0.0.1,34.45.56.666"),
               },
             ],
           },
@@ -226,7 +226,7 @@ describe("WAF Callouts Suite", async function () {
               },
               {
                 key: "X-Forwarded-For",
-                rawValue: new TextEncoder().encode("127.0.0.1,34.45.56.666"),
+                rawValue: new TextEncoder().encode("garbage, 127.0.0.1,34.45.56.666"),
               },
             ],
           },
@@ -262,7 +262,7 @@ describe("WAF Callouts Suite", async function () {
               },
               {
                 key: "X-Forwarded-For",
-                rawValue: new TextEncoder().encode("127.0.0.1,34.45.56.666"),
+                rawValue: new TextEncoder().encode("test, garbage, 127.0.0.1,34.45.56.666"),
               },
             ],
           },
@@ -298,7 +298,7 @@ describe("WAF Callouts Suite", async function () {
               },
               {
                 key: "X-Forwarded-For",
-                rawValue: new TextEncoder().encode("127.0.0.1,34.45.56.666"),
+                rawValue: new TextEncoder().encode("test,garbage, 127.0.0.1,34.45.56.666"),
               },
             ],
           },

--- a/bindings/xlb/src/index.test.ts
+++ b/bindings/xlb/src/index.test.ts
@@ -53,11 +53,10 @@ describe("WAF Callouts Suite", async function () {
   // All tests must specify the firewall policy they match in url. For convenience,
   // the path attribute of the policy is ignored by the server implementation.
   rc_app.post("/v1/projects/:projectNumber/assessments", (req, res) => {
+    expect(req.body.event.userIpAddress).toBe("127.0.0.1");
     const uri = req.body.event.requestedUri;
     const key = req.body.event.siteKey;
     const token = req.body.event.token;
-    const policyKey = uri + "/" + key + "/" + token;
-    console.log("policy key: ", policyKey);
     const policy = testPolicies.get(uri + "/" + key + "/" + token);
     res.json({
       riskAnalysis: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,15 @@
  * @fileoverview reCAPTCHA Enterprise TypeScript Library.
  */
 export { InitError, NetworkError, ParseError, RecaptchaError } from "./error";
-export { AllowAction, BlockAction, InjectJsAction, RedirectAction, SetHeaderAction, SubstituteAction } from "./action";
+export {
+  AllowAction,
+  BlockAction,
+  InjectJsAction,
+  RedirectAction,
+  SetHeaderAction,
+  SubstituteAction,
+  Action,
+} from "./action";
 
 export { Assessment, Event, FirewallPolicy, UserInfo } from "./assessment";
 
@@ -43,7 +51,7 @@ export {
   policyConditionMatch,
   policyPathMatch,
   processRequest,
-  callListFirewallPolicies
+  callListFirewallPolicies,
 } from "./policy";
 
 /** @type {string} */
@@ -73,6 +81,7 @@ export interface RecaptchaConfig {
   credentialPath?: string;
   accountId?: string;
   username?: string;
+  challengePageUrl?: string;
 }
 
 export class DebugTrace {


### PR DESCRIPTION
Tested and confirmed that Envoy has a reliable client IP address embedded in the xff chain via testing and docs: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for

Fixing type assertions and typing issues.